### PR TITLE
Added use-package installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,6 @@ Then add the following to your init.el:
 (require 'flycheck-clj-kondo)
 ```
 
-### el-get
-
-Install via [el-get](https://github.com/dimitri/el-get):
-
-``` emacs-lisp
-(el-get-bundle flycheck-clj-kondo
-  :url "https://raw.githubusercontent.com/borkdude/flycheck-clj-kondo/master/flycheck-clj-kondo.el"
-  (require 'flycheck-clj-kondo))
-```
-
 ### use-package
 
 Install via [use-package](https://jwiegley.github.io/use-package/):
@@ -46,8 +36,17 @@ Install via [use-package](https://jwiegley.github.io/use-package/):
 ;; then install the checker as soon as `clojure-mode' is loaded
 (use-package clojure-mode
   :ensure t
-  ...
   :config
+  (require 'flycheck-clj-kondo))
+```
+
+### el-get
+
+Install via [el-get](https://github.com/dimitri/el-get):
+
+``` emacs-lisp
+(el-get-bundle flycheck-clj-kondo
+  :url "https://raw.githubusercontent.com/borkdude/flycheck-clj-kondo/master/flycheck-clj-kondo.el"
   (require 'flycheck-clj-kondo))
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,23 @@ Install via [el-get](https://github.com/dimitri/el-get):
   (require 'flycheck-clj-kondo))
 ```
 
+### use-package
+
+Install via [use-package](https://jwiegley.github.io/use-package/):
+
+```emacs-lisp
+;; First install the package:
+(use-package flycheck-clj-kondo
+  :ensure t)
+
+;; then install the checker as soon as `clojure-mode' is loaded
+(use-package clojure-mode
+  :ensure t
+  ...
+  :config
+  (require 'flycheck-clj-kondo))
+```
+
 ## Multiple linters
 
 To set up multiple linters, e.g. in combination with


### PR DESCRIPTION
Since it involves two separate steps, the `use-package` documentation is a bit more verbose than the others