### PR TITLE
Modified predicate for activating checkers so that it can fallback to…

### DIFF
--- a/flycheck-clj-kondo.el
+++ b/flycheck-clj-kondo.el
@@ -63,7 +63,17 @@ Argument EXTRA-ARGS: passes extra args to the checker."
         (warning line-start "<stdin>:" line ":" column ": " (0+ not-newline) "warning: " (message) line-end)
         (info line-start "<stdin>:" line ":" column ": " (0+ not-newline) "info: " (message) line-end))
        :modes (,mode)
-       :predicate (lambda () (string= ,lang (file-name-extension (buffer-file-name)))))))
+       :predicate (lambda ()
+                    (let (buffer-file-name (buffer-file-name))
+                      (if buffer-file-name
+                          ;; If there is an associated file with buffer, use file name extension
+                          ;; to infer which language to turn on.
+                          (string= ,lang (file-name-extension buffer-file-name))
+                        ;; Else use the mode to infer which language to turn on.
+                        (when (or (and (equal 'clojure-mode major-mode) (string= ,lang "clj"))
+                                  (and (equal 'clojurescript-mode major-mode) (string= ,lang "cljs"))
+                                  (and (equal 'clojurec-mode major-mode) (string= ,lang "cljc")))
+                          t)))))))
 
 (defmacro flycheck-clj-kondo-define-checkers (&rest extra-args)
   "Defines all clj-kondo checkers.


### PR DESCRIPTION
… using the major mode when there are no associated files with the Clojure buffer.

This allows flycheck-clj-kondo to be enabled and linting buffers that don't have a file associated with them. I often create buffers with no files and start a REPL just to mess and around, and I was missing having clj-kondo available in them.

I tested the following combination on my desktop:
* clojure-mode no file
* clojurec-mode no file
* clojurescript-mode no file
* clojure-mode with file
* clojurec-mode with file
* clojurescript-mode with file