### PR TITLE
Support for file-less buffers (try 2)

### DIFF
--- a/flycheck-clj-kondo.el
+++ b/flycheck-clj-kondo.el
@@ -63,7 +63,17 @@ Argument EXTRA-ARGS: passes extra args to the checker."
         (warning line-start "<stdin>:" line ":" column ": " (0+ not-newline) "warning: " (message) line-end)
         (info line-start "<stdin>:" line ":" column ": " (0+ not-newline) "info: " (message) line-end))
        :modes (,mode)
-       :predicate (lambda () (string= ,lang (file-name-extension (buffer-file-name)))))))
+       :predicate (lambda ()
+                    (let ((buffer-file-name (buffer-file-name)))
+                      (if buffer-file-name
+                          ;; If there is an associated file with buffer, use file name extension
+                          ;; to infer which language to turn on.
+                          (string= ,lang (file-name-extension buffer-file-name))
+                        ;; Else use the mode to infer which language to turn on.
+                        ,(pcase lang
+                           ("clj" `(equal 'clojure-mode major-mode))
+                           ("cljs" `(equal 'clojurescript-mode major-mode))
+                           ("cljc" `(equal 'clojurec-mode major-mode)))))))))
 
 (defmacro flycheck-clj-kondo-define-checkers (&rest extra-args)
   "Defines all clj-kondo checkers.

--- a/flycheck-clj-kondo.el
+++ b/flycheck-clj-kondo.el
@@ -64,16 +64,15 @@ Argument EXTRA-ARGS: passes extra args to the checker."
         (info line-start "<stdin>:" line ":" column ": " (0+ not-newline) "info: " (message) line-end))
        :modes (,mode)
        :predicate (lambda ()
-                    (let ((buffer-file-name (buffer-file-name)))
-                      (if buffer-file-name
-                          ;; If there is an associated file with buffer, use file name extension
-                          ;; to infer which language to turn on.
-                          (string= ,lang (file-name-extension buffer-file-name))
-                        ;; Else use the mode to infer which language to turn on.
-                        ,(pcase lang
-                           ("clj" `(equal 'clojure-mode major-mode))
-                           ("cljs" `(equal 'clojurescript-mode major-mode))
-                           ("cljc" `(equal 'clojurec-mode major-mode)))))))))
+                    (if buffer-file-name
+                        ;; If there is an associated file with buffer, use file name extension
+                        ;; to infer which language to turn on.
+                        (string= ,lang (file-name-extension buffer-file-name))
+                      ;; Else use the mode to infer which language to turn on.
+                      ,(pcase lang
+                         ("clj" `(equal 'clojure-mode major-mode))
+                         ("cljs" `(equal 'clojurescript-mode major-mode))
+                         ("cljc" `(equal 'clojurec-mode major-mode))))))))
 
 (defmacro flycheck-clj-kondo-define-checkers (&rest extra-args)
   "Defines all clj-kondo checkers.


### PR DESCRIPTION
Same as: https://github.com/borkdude/flycheck-clj-kondo/pull/5 , but fixes the issue that one had when handling "edn" files.

The bug was that I forgot to wrap the `let` in an extra set of parenthesis, so buffer-file-name was always nil, and it would never use the file name to choose the checker. Seems like I would need a clj-kondo for emacs-lisp as well ;)

For clj, cljs, and cljc, it turned out relying on the mode always worked anyways, which is why I didn't catch that bug in the prior PR, but edn has no mode, so only the filename can be used, and this is where it failed.

I decided to also change the logic for the mode picking, to use pcase and choose the right equality check to use at macro-expansion, I found that to be clearer and better.

This time I tested all the following cases:

* clojure-mode no file
* clojurec-mode no file
* clojurescript-mode no file
* clojure-mode with clj file
* clojurec-mode with cljc file
* clojurescript-mode cljs with file
* clojure-mode with edn file
* clojurescript-mode with edn file
* clojurec-mode with edn file

I also tested the scenario where someone chooses the wrong major mode for the given file, say you open a `.clj` file and choose `clojurec-mode` for example. In those cases, no clj-kondo linters are activated, which is the current behavior as well, because it has an associated file, it will use the file based predicate, and that would make it false for the mode flycheck is using.