### PR TITLE
fix: detect project specific clj-kondo config

### DIFF
--- a/flycheck-clj-kondo.el
+++ b/flycheck-clj-kondo.el
@@ -72,7 +72,11 @@ Argument EXTRA-ARGS: passes extra args to the checker."
                       ,(pcase lang
                          ("clj" `(equal 'clojure-mode major-mode))
                          ("cljs" `(equal 'clojurescript-mode major-mode))
-                         ("cljc" `(equal 'clojurec-mode major-mode))))))))
+                         ("cljc" `(equal 'clojurec-mode major-mode)))))
+       :working-directory (lambda (x)
+                            (if buffer-file-name
+                                (file-name-directory buffer-file-name)
+                              default-directory)))))
 
 (defmacro flycheck-clj-kondo-define-checkers (&rest extra-args)
   "Defines all clj-kondo checkers.


### PR DESCRIPTION
Set the working directory to the directory of the current buffer.  This
allows clj-kondo to find any project specific config.