### PR TITLE
Add a readme project setup note about .clj-kondo

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ This ensures that the clj-kondo checkers are the first ones in the `flycheck-che
   (flycheck-add-next-checker (car checkers) (cons 'error (cdr checkers))))
 ```
 
+## Project Setup
+
+To lint across namespaces in a project, clj-condo needs a directory to store cached data. Create a `.clj-kondo` directory and lint the entire classpath from the [command line](https://github.com/clj-kondo/clj-kondo#project-setup).
+
 ## Testing
 
 Make sure [Eldev](https://github.com/doublep/eldev) is installed and


### PR DESCRIPTION
While trying clj-kondo from the command-line, and from Emacs, i noticed that arity checks were flagged on the command-line, but not in emacs.

I then realized that on the command-line, i had scanned a directory, whereas my guess was that Emacs flycheck scans per file.
Fortunately, the main documentation had a note about project setup, and after I created the .clj-kondo directory and ran an initial directory check, flycheck flagged the incorrect arity as well.

To make things easier to find, I'd like to link Project Setup to the flycheck-clj-kondo readme.