### PR TITLE
Include new clj-kondo namespace error in basic cljs test

### DIFF
--- a/test/flycheck-clj-kondo-test.el
+++ b/test/flycheck-clj-kondo-test.el
@@ -39,6 +39,8 @@
 (flycheck-ert-def-checker-test clj-kondo-cljs cljs basic
   (flycheck-ert-should-syntax-check
    "test/corpus/basic.cljs" 'clojurescript-mode
+   '(3 5 error "Namespace name does not match file name: cond-without-else1"
+       :checker clj-kondo-cljs)
    '(11 3 warning "use :else as the catch-all test expression in cond"
         :checker clj-kondo-cljs)
    '(18 3 warning "use :else as the catch-all test expression in cond"


### PR DESCRIPTION
A recent clj-kondo release marks as an error a namespace declaration that does not correspond to the expected physical path. This causes the cljs tests to break (#19).

This patch updates the test's error list to include the new error.

Thanks