### PR TITLE
Update clojure-ts-mode support

### DIFF
--- a/Eldev
+++ b/Eldev
@@ -3,4 +3,7 @@
 ;; Autodetermined by `eldev init'.
 (eldev-use-package-archive 'melpa)
 
-(eldev-add-extra-dependencies 'test 'clojure-mode 'clojure-ts-mode)
+(eldev-add-extra-dependencies 'test 'clojure-mode)
+
+(when (version<=  "29.1" emacs-version)
+  (eldev-add-extra-dependencies 'test 'clojure-ts-mode))

--- a/Eldev
+++ b/Eldev
@@ -3,4 +3,4 @@
 ;; Autodetermined by `eldev init'.
 (eldev-use-package-archive 'melpa)
 
-(eldev-add-extra-dependencies 'test 'clojure-mode)
+(eldev-add-extra-dependencies 'test 'clojure-mode 'clojure-ts-mode)

--- a/flycheck-clj-kondo.el
+++ b/flycheck-clj-kondo.el
@@ -87,8 +87,8 @@ Argument EXTRA-ARGS: passes extra args to the checker."
                    ;; Else use the mode to infer which language to turn on.
                    (pcase ,lang
                      ("clj"  (member major-mode '(clojure-mode clojure-ts-mode)))
-                     ("cljs" (member major-mode '(clojurescript-mode clojurescritps-ts-mode)))
-                     ("cljc" (member major-mode '(clojurec-mode clojurec-ts-mode))))))))
+                     ("cljs" (member major-mode '(clojurescript-mode clojure-ts-clojurescript-mode)))
+                     ("cljc" (member major-mode '(clojurec-mode clojure-ts-clojurec-mode))))))))
 
 ;; (macroexpand-1 '(flycheck-clj-kondo--define-checker clj-kondo-clj "clj" clojure-mode "--cache"))
 
@@ -97,8 +97,8 @@ Argument EXTRA-ARGS: passes extra args to the checker."
 Argument EXTRA-ARGS: passes extra arguments to the checkers."
   `(progn
      (flycheck-clj-kondo--define-checker clj-kondo-clj "clj" (clojure-mode clojure-ts-mode) ,@extra-args)
-     (flycheck-clj-kondo--define-checker clj-kondo-cljs "cljs" (clojurescript-mode clojurescript-ts-mode) ,@extra-args)
-     (flycheck-clj-kondo--define-checker clj-kondo-cljc "cljc" (clojurec-mode clojurec-ts-mode) ,@extra-args)
+     (flycheck-clj-kondo--define-checker clj-kondo-cljs "cljs" (clojurescript-mode clojure-ts-clojurescript-mode) ,@extra-args)
+     (flycheck-clj-kondo--define-checker clj-kondo-cljc "cljc" (clojurec-mode clojure-ts-clojurec-mode) ,@extra-args)
      (flycheck-clj-kondo--define-checker clj-kondo-edn "edn" (clojure-mode clojure-ts-mode) ,@extra-args)
      (dolist (element '(clj-kondo-clj clj-kondo-cljs clj-kondo-cljc clj-kondo-edn))
        (add-to-list 'flycheck-checkers element))))

--- a/test/flycheck-clj-kondo-test.el
+++ b/test/flycheck-clj-kondo-test.el
@@ -58,54 +58,55 @@
 
 ;; Tests for clojure-ts-mode
 
-(flycheck-ert-def-checker-test clj-kondo-clj clj basic-ts
-  (flycheck-ert-should-syntax-check
-   "test/corpus/basic.clj" 'clojure-ts-mode
-   '(3 23 warning "unused binding y"
-       :checker clj-kondo-clj)
-   '(3 25 warning "unused binding z"
-       :checker clj-kondo-clj)
-   '(4 65 warning "unused binding y"
-       :checker clj-kondo-clj)
-   '(5 25 warning "unused binding y"
-       :checker clj-kondo-clj)
-   '(5 29 warning "unused binding zs"
-       :checker clj-kondo-clj)
-   '(7 1 error "corpus.basic/public-fixed is called with 1 arg but expects 3"
-       :checker clj-kondo-clj)
-   '(10 1 error "corpus.basic/public-multi-arity is called with 3 args but expects 1 or 2"
-        :checker clj-kondo-clj)
-   '(11 1 error "corpus.basic/public-varargs is called with 1 arg but expects 2 or more"
-       :checker clj-kondo-clj)))
+(when (version<=  "29.1" emacs-version)
+  (flycheck-ert-def-checker-test clj-kondo-clj clj basic-ts
+                                 (flycheck-ert-should-syntax-check
+                                  "test/corpus/basic.clj" 'clojure-ts-mode
+                                  '(3 23 warning "unused binding y"
+                                    :checker clj-kondo-clj)
+                                  '(3 25 warning "unused binding z"
+                                    :checker clj-kondo-clj)
+                                  '(4 65 warning "unused binding y"
+                                    :checker clj-kondo-clj)
+                                  '(5 25 warning "unused binding y"
+                                    :checker clj-kondo-clj)
+                                  '(5 29 warning "unused binding zs"
+                                    :checker clj-kondo-clj)
+                                  '(7 1 error "corpus.basic/public-fixed is called with 1 arg but expects 3"
+                                    :checker clj-kondo-clj)
+                                  '(10 1 error "corpus.basic/public-multi-arity is called with 3 args but expects 1 or 2"
+                                    :checker clj-kondo-clj)
+                                  '(11 1 error "corpus.basic/public-varargs is called with 1 arg but expects 2 or more"
+                                    :checker clj-kondo-clj)))
 
-(flycheck-ert-def-checker-test clj-kondo-cljc cljc basic-ts
-  (flycheck-ert-should-syntax-check
-   "test/corpus/basic.cljc" 'clojure-ts-clojurec-mode
-   '(3 26 warning "unused binding y"
-       :checker clj-kondo-cljc)
-   '(13 9 error "test.corpus.basic/foo is called with 1 arg but expects 2"
-        :checker clj-kondo-cljc)
-   '(14 10 error "test.corpus.basic/foo is called with 2 args but expects 1"
-        :checker clj-kondo-cljc)
-   '(21 1 error "test.corpus.basic/bar is called with 3 args but expects 1"
-        :checker clj-kondo-cljc)))
+  (flycheck-ert-def-checker-test clj-kondo-cljc cljc basic-ts
+                                 (flycheck-ert-should-syntax-check
+                                  "test/corpus/basic.cljc" 'clojure-ts-clojurec-mode
+                                  '(3 26 warning "unused binding y"
+                                    :checker clj-kondo-cljc)
+                                  '(13 9 error "test.corpus.basic/foo is called with 1 arg but expects 2"
+                                    :checker clj-kondo-cljc)
+                                  '(14 10 error "test.corpus.basic/foo is called with 2 args but expects 1"
+                                    :checker clj-kondo-cljc)
+                                  '(21 1 error "test.corpus.basic/bar is called with 3 args but expects 1"
+                                    :checker clj-kondo-cljc)))
 
-(flycheck-ert-def-checker-test clj-kondo-cljs cljs basic-ts
-  (flycheck-ert-should-syntax-check
-   "test/corpus/basic.cljs" 'clojure-ts-clojurescript-mode
-   '(3 5 error "Namespace name does not match file name: cond-without-else1"
-       :checker clj-kondo-cljs)
-   '(11 3 warning "use :else as the catch-all test expression in cond"
-        :checker clj-kondo-cljs)
-   '(18 3 warning "use :else as the catch-all test expression in cond"
-        :checker clj-kondo-cljs)))
+  (flycheck-ert-def-checker-test clj-kondo-cljs cljs basic-ts
+                                 (flycheck-ert-should-syntax-check
+                                  "test/corpus/basic.cljs" 'clojure-ts-clojurescript-mode
+                                  '(3 5 error "Namespace name does not match file name: cond-without-else1"
+                                    :checker clj-kondo-cljs)
+                                  '(11 3 warning "use :else as the catch-all test expression in cond"
+                                    :checker clj-kondo-cljs)
+                                  '(18 3 warning "use :else as the catch-all test expression in cond"
+                                    :checker clj-kondo-cljs)))
 
-(flycheck-ert-def-checker-test clj-kondo-edn edn basic-ts
-  (flycheck-ert-should-syntax-check
-   "test/corpus/basic.edn" 'clojure-ts-mode
-   '(1 10 error "duplicate key a"
-        :checker clj-kondo-edn)))
+  (flycheck-ert-def-checker-test clj-kondo-edn edn basic-ts
+                                 (flycheck-ert-should-syntax-check
+                                  "test/corpus/basic.edn" 'clojure-ts-mode
+                                  '(1 10 error "duplicate key a"
+                                    :checker clj-kondo-edn)))
 
-(flycheck-ert-def-checker-test clj-kondo-clj clj utf8-ts
-  (flycheck-ert-should-syntax-check
-   "test/corpus/utf8.clj" 'clojure-ts-mode))
+  (flycheck-ert-def-checker-test clj-kondo-clj clj utf8-ts
+                                 (flycheck-ert-should-syntax-check
+                                  "test/corpus/utf8.clj" 'clojure-ts-mode)))

--- a/test/flycheck-clj-kondo-test.el
+++ b/test/flycheck-clj-kondo-test.el
@@ -55,3 +55,57 @@
 (flycheck-ert-def-checker-test clj-kondo-clj clj utf8
   (flycheck-ert-should-syntax-check
    "test/corpus/utf8.clj" 'clojure-mode))
+
+;; Tests for clojure-ts-mode
+
+(flycheck-ert-def-checker-test clj-kondo-clj clj basic-ts
+  (flycheck-ert-should-syntax-check
+   "test/corpus/basic.clj" 'clojure-ts-mode
+   '(3 23 warning "unused binding y"
+       :checker clj-kondo-clj)
+   '(3 25 warning "unused binding z"
+       :checker clj-kondo-clj)
+   '(4 65 warning "unused binding y"
+       :checker clj-kondo-clj)
+   '(5 25 warning "unused binding y"
+       :checker clj-kondo-clj)
+   '(5 29 warning "unused binding zs"
+       :checker clj-kondo-clj)
+   '(7 1 error "corpus.basic/public-fixed is called with 1 arg but expects 3"
+       :checker clj-kondo-clj)
+   '(10 1 error "corpus.basic/public-multi-arity is called with 3 args but expects 1 or 2"
+        :checker clj-kondo-clj)
+   '(11 1 error "corpus.basic/public-varargs is called with 1 arg but expects 2 or more"
+       :checker clj-kondo-clj)))
+
+(flycheck-ert-def-checker-test clj-kondo-cljc cljc basic-ts
+  (flycheck-ert-should-syntax-check
+   "test/corpus/basic.cljc" 'clojure-ts-clojurec-mode
+   '(3 26 warning "unused binding y"
+       :checker clj-kondo-cljc)
+   '(13 9 error "test.corpus.basic/foo is called with 1 arg but expects 2"
+        :checker clj-kondo-cljc)
+   '(14 10 error "test.corpus.basic/foo is called with 2 args but expects 1"
+        :checker clj-kondo-cljc)
+   '(21 1 error "test.corpus.basic/bar is called with 3 args but expects 1"
+        :checker clj-kondo-cljc)))
+
+(flycheck-ert-def-checker-test clj-kondo-cljs cljs basic-ts
+  (flycheck-ert-should-syntax-check
+   "test/corpus/basic.cljs" 'clojure-ts-clojurescript-mode
+   '(3 5 error "Namespace name does not match file name: cond-without-else1"
+       :checker clj-kondo-cljs)
+   '(11 3 warning "use :else as the catch-all test expression in cond"
+        :checker clj-kondo-cljs)
+   '(18 3 warning "use :else as the catch-all test expression in cond"
+        :checker clj-kondo-cljs)))
+
+(flycheck-ert-def-checker-test clj-kondo-edn edn basic-ts
+  (flycheck-ert-should-syntax-check
+   "test/corpus/basic.edn" 'clojure-ts-mode
+   '(1 10 error "duplicate key a"
+        :checker clj-kondo-edn)))
+
+(flycheck-ert-def-checker-test clj-kondo-clj clj utf8-ts
+  (flycheck-ert-should-syntax-check
+   "test/corpus/utf8.clj" 'clojure-ts-mode))


### PR DESCRIPTION
This is a follow up PR to https://github.com/borkdude/flycheck-clj-kondo/pull/26.

- Since the previous PR the derived-major-mode names have been updated to follow the emacs-lisp naming conventions. https://github.com/clojure-emacs/clojure-ts-mode/blob/main/CHANGELOG.md#021-2024-02-14
- Also duplicated the existing tests for `clojure-ts-mode`. 